### PR TITLE
Improve coloring for bar-card

### DIFF
--- a/themes/synthwave.yaml
+++ b/themes/synthwave.yaml
@@ -64,3 +64,7 @@ synthwave:
 
   # Left Menu
   paper-listbox-background-color: 'var(--light-primary-color)' # Background
+
+  # bar-card compatibility
+  # https://github.com/custom-cards/bar-card
+  custom-bar-card-color: 'var(--accent-color)'


### PR DESCRIPTION
See custom-cards/bar-card#17

Before: 
![image](https://user-images.githubusercontent.com/1885159/63155601-2ccc2a00-c013-11e9-8543-203325f58b92.png)

After:
<img width="350" alt="Screenshot 2019-08-16 at 10 47 52" src="https://user-images.githubusercontent.com/1885159/63155688-5f762280-c013-11e9-9853-5757a65f84e5.png">