### PR TITLE
Fix color of switches and sliders

### DIFF
--- a/themes/synthwave.yaml
+++ b/themes/synthwave.yaml
@@ -49,6 +49,7 @@ synthwave:
   # switches
   paper-toggle-button-checked-button-color: '#FFF' # Knob On
   paper-toggle-button-checked-bar-color: 'var(--dark-primary-color)' # Background On
+  switch-checked-color: 'var(--dark-primary-color)' # Background On
   paper-toggle-button-unchecked-button-color: '#FFF' # Knob Off
   paper-toggle-button-unchecked-bar-color: 'var(--disabled-text-color)' # Background Off
 

--- a/themes/synthwave.yaml
+++ b/themes/synthwave.yaml
@@ -34,6 +34,7 @@ synthwave:
   # --toggle-button-unchecked-color: 'var(--accent-color)'
   slider-color: 'var(--primary-color)'
   slider-secondary-color: 'var(--light-primary-color)'
+  paper-slider-active-color: 'var(--dark-primary-color)'
   # slider-bar-color: 'var(--disabled-text-color)'
   
   # mwc - for some reason it's buttons


### PR DESCRIPTION
As reported in #13 the color of active switches and sliders were very close to the background colour, making it hard to tell if the switch was active or not.

I dug out the CSS variables responsible, and applied the pink color to them.