### PR TITLE
Add colors for simple-thermostat buttons

### DIFF
--- a/themes/synthwave.yaml
+++ b/themes/synthwave.yaml
@@ -94,3 +94,8 @@ synthwave:
 
   # Scrollbar
   scrollbar-thumb-color: 'var(--divider-color)'
+
+  # simple-thermostat buttons
+  # https://github.com/nervetattoo/simple-thermostat
+  st-mode-background: 'var(--primary-background-color)'
+  st-mode-active-background: 'var(--dark-primary-color)'


### PR DESCRIPTION
Simple-Thermostat's default colors currently look like this:

<img width="478" alt="Screen Shot 2020-05-02 at 6 59 41 PM" src="https://user-images.githubusercontent.com/7717888/80895136-26680600-8ca7-11ea-9ff1-9d50abb4bfcf.png">

After this commit, they will look like this:

<img width="478" alt="Screen Shot 2020-05-02 at 6 59 49 PM" src="https://user-images.githubusercontent.com/7717888/80895141-3384f500-8ca7-11ea-8a99-3ea0f0235e52.png">
