### PR TITLE
Make user badge initials image visible

### DIFF
--- a/themes/synthwave.yaml
+++ b/themes/synthwave.yaml
@@ -4,6 +4,7 @@ synthwave:
   secondary-text-color: '#ffffffca'
   text-primary-color: '#f4eee4'
   disabled-text-color: '#bdbdbd'
+  text-light-primary-color: '#fff'
 
   # main interface colors
   primary-color: '#f92aad'


### PR DESCRIPTION
Addresses - #38 

As you can see user badge can be seen

<img width="191" alt="Screenshot 2022-03-28 at 13 26 39" src="https://user-images.githubusercontent.com/17881447/160397687-3f72e7c1-2c1b-422a-9d24-15e807b5a4b7.png">
