### PR TITLE
Fix inputs styling

### DIFF
--- a/themes/synthwave.yaml
+++ b/themes/synthwave.yaml
@@ -77,6 +77,25 @@ synthwave:
   table-row-background-color: 'var(--divider-color)'
   table-row-alternative-background-color: 'var(--light-primary-color)'
   
+  # Inputs
+  mdc-select-fill-color: 'var(--card-background-color)'
+  mdc-text-field-fill-color: 'var(--card-background-color)'
+  mdc-select-ink-color: 'var(--primary-text-color)'
+  mdc-select-label-ink-color: 'var(--primary-text-color)'
+  mdc-select-dropdown-icon-color: 'var(--primary-text-color)'
+  mdc-text-field-label-ink-color: 'var(--primary-text-color)'
+  mdc-text-field-ink-color: 'var(--primary-text-color)'
+  input-dropdown-icon-color: 'var(--primary-text-color)'
+  # Inputs Ripple/line
+  mdc-ripple-color: 'var(--primary-text-color)'
+  mdc-text-field-idle-line-color: 'var(--primary-text-color)'
+  mdc-select-idle-line-color: 'var(--primary-text-color)'
+  mdc-select-hover-line-color: 'var(--primary-text-color)'
+  mdc-text-field-hover-line-color: 'var(--primary-text-color)'
+  # Inputs Disabled
+  mdc-select-disabled-fill-color: 'var(--primary-background-color)'
+  mdc-select-disabled-ink-color: 'var(--disabled-text-color)'
+  
   ###
 
   # UI

--- a/themes/synthwave.yaml
+++ b/themes/synthwave.yaml
@@ -95,6 +95,7 @@ synthwave:
   # Inputs Disabled
   mdc-select-disabled-fill-color: 'var(--primary-background-color)'
   mdc-select-disabled-ink-color: 'var(--disabled-text-color)'
+  mdc-select-disabled-dropdown-icon-color: 'var(--disabled-text-color)'
   
   ###
 

--- a/themes/synthwave.yaml
+++ b/themes/synthwave.yaml
@@ -79,23 +79,26 @@ synthwave:
   
   # Inputs
   mdc-select-fill-color: 'var(--card-background-color)'
-  mdc-text-field-fill-color: 'var(--card-background-color)'
   mdc-select-ink-color: 'var(--primary-text-color)'
   mdc-select-label-ink-color: 'var(--primary-text-color)'
   mdc-select-dropdown-icon-color: 'var(--primary-text-color)'
   mdc-text-field-label-ink-color: 'var(--primary-text-color)'
   mdc-text-field-ink-color: 'var(--primary-text-color)'
+  mdc-text-field-fill-color: 'var(--card-background-color)'
   input-dropdown-icon-color: 'var(--primary-text-color)'
   # Inputs Ripple/line
   mdc-ripple-color: 'var(--primary-text-color)'
   mdc-text-field-idle-line-color: 'var(--primary-text-color)'
+  mdc-text-field-hover-line-color: 'var(--primary-text-color)'
   mdc-select-idle-line-color: 'var(--primary-text-color)'
   mdc-select-hover-line-color: 'var(--primary-text-color)'
-  mdc-text-field-hover-line-color: 'var(--primary-text-color)'
   # Inputs Disabled
   mdc-select-disabled-fill-color: 'var(--primary-background-color)'
   mdc-select-disabled-ink-color: 'var(--disabled-text-color)'
   mdc-select-disabled-dropdown-icon-color: 'var(--disabled-text-color)'
+  mdc-text-field-disabled-fill-color: 'var(--primary-background-color)'
+  mdc-text-field-disabled-ink-color: 'var(--disabled-text-color)'
+  mdc-text-field-disabled-dropdown-icon-color: 'var(--disabled-text-color)'
   
   ###
 


### PR DESCRIPTION
# Before:

<img width="996" alt="Screenshot 2022-03-28 at 13 42 18" src="https://user-images.githubusercontent.com/17881447/160403811-07fe4030-2d89-4bb9-bcc1-5ae4da752d8f.png">

# After: 

<img width="995" alt="Screenshot 2022-03-28 at 14 03 46" src="https://user-images.githubusercontent.com/17881447/160403804-40e7765a-728e-4418-9933-e350c753a412.png">
<img width="989" alt="Screenshot 2022-03-28 at 14 03 13" src="https://user-images.githubusercontent.com/17881447/160403809-9925fa24-ed56-4222-863a-cc1972ef8270.png">

I believe this covers #37 + rest of the input types