### PR TITLE
Provide color tokens to support new features

### DIFF
--- a/themes/synthwave.yaml
+++ b/themes/synthwave.yaml
@@ -148,9 +148,9 @@ synthwave:
   st-mode-active-background: 'var(--dark-primary-color)'
 
   # core color tokens
-  ha-color-primary-05: '#18000f'
-  ha-color-primary-10: '#3b0126'
-  ha-color-primary-20: '#860356'
+  ha-color-primary-05: '#720a49'
+  ha-color-primary-10: '#800952'
+  ha-color-primary-20: '#9d0e66'
   ha-color-primary-30: '#d40588'
   ha-color-primary-40: 'var(--primary-color)'
   ha-color-primary-50: '#ee56b6'

--- a/themes/synthwave.yaml
+++ b/themes/synthwave.yaml
@@ -146,3 +146,129 @@ synthwave:
   # https://github.com/nervetattoo/simple-thermostat
   st-mode-background: 'var(--primary-background-color)'
   st-mode-active-background: 'var(--dark-primary-color)'
+
+  # core color tokens
+  ha-color-primary-05: '#18000f'
+  ha-color-primary-10: '#3b0126'
+  ha-color-primary-20: '#860356'
+  ha-color-primary-30: '#d40588'
+  ha-color-primary-40: 'var(--primary-color)'
+  ha-color-primary-50: '#ee56b6'
+  ha-color-primary-60: '#e77ec0'
+  ha-color-primary-70: '#e4a2cc'
+  ha-color-primary-80: '#e6c2d9'
+  ha-color-primary-90: '#f6d9ec'
+  ha-color-primary-95: '#f4f0f2'
+  ha-color-primary-99: '#fcfcfc'
+
+  ha-color-neutral-05: '#131216'
+  ha-color-neutral-10: '#1e1d22'
+  ha-color-neutral-20: '#333139'
+  ha-color-neutral-30: '#47444f'
+  ha-color-neutral-40: '#5b5665'
+  ha-color-neutral-50: '#767084'
+  ha-color-neutral-60: '#9590a1'
+  ha-color-neutral-70: '#ada9b6'
+  ha-color-neutral-80: '#cac7d0'
+  ha-color-neutral-90: '#e4e3e7'
+  ha-color-neutral-95: '#f1f1f3'
+
+  # semantic color tokens from the default dark theme (Home Assistant 2026.1)
+  ha-color-text-primary: var(--white-color)
+  ha-color-text-secondary: var(--ha-color-neutral-80)
+  ha-color-text-link: var(--ha-color-primary-60)
+
+  ha-color-border-normal: var(--ha-color-primary-50)
+
+  ha-color-border-neutral-quiet: var(--ha-color-neutral-40)
+  ha-color-border-neutral-normal: var(--ha-color-neutral-50)
+  ha-color-border-neutral-loud: var(--ha-color-neutral-70)
+
+  ha-color-border-danger-normal: var(--ha-color-red-50)
+  ha-color-border-danger-loud: var(--ha-color-red-50)
+
+  ha-color-border-warning-normal: var(--ha-color-orange-50)
+  ha-color-border-warning-loud: var(--ha-color-orange-50)
+
+  ha-color-fill-primary-quiet-resting: var(--ha-color-primary-05)
+  ha-color-fill-primary-quiet-hover: var(--ha-color-primary-10)
+  ha-color-fill-primary-quiet-active: var(--ha-color-primary-05)
+
+  ha-color-fill-primary-normal-resting: var(--ha-color-primary-10)
+  ha-color-fill-primary-normal-hover: var(--ha-color-primary-20)
+  ha-color-fill-primary-normal-active: var(--ha-color-primary-10)
+
+  ha-color-fill-neutral-quiet-resting: var(--ha-color-neutral-05)
+  ha-color-fill-neutral-quiet-f-fill-neutral-quiet-active: var(--ha-color-neutral-00)
+
+  ha-color-fill-neutral-normal-resting: var(--ha-color-neutral-10)
+  ha-color-fill-neutral-normal-hover: var(--ha-color-neutral-20)
+  ha-color-fill-neutral-normal-active: var(--ha-color-neutral-10)
+
+  ha-color-fill-disabled-quiet-resting: var(--ha-color-neutral-10)
+
+  ha-color-fill-disabled-normal-resting: var(--ha-color-neutral-20)
+
+  ha-color-fill-disabled-loud-resting: var(--ha-color-neutral-30)
+
+  ha-color-fill-danger-quiet-resting: var(--ha-color-red-05)
+  ha-color-fill-danger-quiet-hover: var(--ha-color-red-10)
+  ha-color-fill-danger-quiet-active: var(--ha-color-red-05)
+
+  ha-color-fill-danger-normal-resting: var(--ha-color-red-10)
+  ha-color-fill-danger-normal-hover: var(--ha-color-red-20)
+  ha-color-fill-danger-normal-active: var(--ha-color-red-10)
+
+  ha-color-fill-danger-loud-resting: var(--ha-color-red-40)
+  ha-color-fill-danger-loud-hover: var(--ha-color-red-30)
+  ha-color-fill-danger-loud-active: var(--ha-color-red-40)
+
+  ha-color-fill-warning-quiet-resting: var(--ha-color-orange-05)
+  ha-color-fill-warning-quiet-hover: var(--ha-color-orange-10)
+  ha-color-fill-warning-quiet-active: var(--ha-color-orange-05)
+
+  ha-color-fill-warning-normal-resting: var(--ha-color-orange-10)
+  ha-color-fill-warning-normal-hover: var(--ha-color-orange-20)
+  ha-color-fill-warning-normal-active: var(--ha-color-orange-10)
+
+  ha-color-fill-warning-loud-resting: var(--ha-color-orange-40)
+  ha-color-fill-warning-loud-hover: var(--ha-color-orange-30)
+  ha-color-fill-warning-loud-active: var(--ha-color-orange-40)
+
+  ha-color-fill-success-quiet-resting: var(--ha-color-green-05)
+  ha-color-fill-success-quiet-hover: var(--ha-color-green-10)
+  ha-color-fill-success-quiet-active: var(--ha-color-green-05)
+
+  ha-color-fill-success-normal-resting: var(--ha-color-green-10)
+  ha-color-fill-success-normal-hover: var(--ha-color-green-20)
+  ha-color-fill-success-normal-active: var(--ha-color-green-10)
+
+  ha-color-fill-success-loud-resting: var(--ha-color-green-40)
+  ha-color-fill-success-loud-hover: var(--ha-color-green-30)
+  ha-color-fill-success-loud-active: var(--ha-color-green-40)
+
+  ha-color-on-primary-quiet: var(--ha-color-primary-70)
+  ha-color-on-primary-normal: var(--ha-color-primary-60)
+
+  ha-color-on-neutral-quiet: var(--ha-color-neutral-70)
+  ha-color-on-neutral-normal: var(--ha-color-neutral-60)
+  ha-color-on-neutral-loud: var(--white-color)
+
+  ha-color-on-disabled-quiet: var(--ha-color-neutral-40)
+  ha-color-on-disabled-normal: var(--ha-color-neutral-50)
+  ha-color-on-disabled-loud: var(--ha-color-neutral-50)
+
+  ha-color-on-danger-quiet: var(--ha-color-red-70)
+  ha-color-on-danger-normal: var(--ha-color-red-60)
+  ha-color-on-danger-loud: var(--white-color)
+
+  ha-color-on-warning-quiet: var(--ha-color-orange-70)
+  ha-color-on-warning-normal: var(--ha-color-orange-60)
+  ha-color-on-warning-loud: var(--white-color)
+
+  ha-color-on-success-quiet: var(--ha-color-green-70)
+  ha-color-on-success-normal: var(--ha-color-green-60)
+  ha-color-on-success-loud: var(--white-color)
+
+  ha-color-surface-default: var(--ha-color-neutral-10)
+  ha-color-on-surface-default: var(--ha-color-neutral-95)


### PR DESCRIPTION
hii

this PR adds color tokens, which hass uses for most of the new components. this ensures that the theme looks decent on newer versions without having to explicitly theme every component 

the color selection could be improved, but it's certainly better than using colors from the default light theme 

a brief comparison:

<img width="363" height="278" alt="image" src="https://github.com/user-attachments/assets/b7949f65-b717-49bd-b4c8-45f53702387b" />

<img width="396" height="241" alt="image" src="https://github.com/user-attachments/assets/20f8eb78-f2eb-4e20-8b6b-40335cb65151" />
