### PR TITLE
Use dark theme as the base and improve some colors

### DIFF
--- a/themes/synthwave.yaml
+++ b/themes/synthwave.yaml
@@ -220,7 +220,7 @@ synthwave:
 
   ha-color-fill-neutral-normal-resting: var(--ha-color-neutral-10)
   ha-color-fill-neutral-normal-hover: var(--ha-color-neutral-20)
-  ha-color-fill-neutral-normal-active: var(--ha-color-neutral-10)
+  ha-color-fill-neutral-normal-active: var(--ha-color-form-background-hover)
   wa-color-neutral-fill-normal: var(--ha-color-form-background-hover)
 
   ha-color-fill-disabled-quiet-resting: var(--ha-color-neutral-10)

--- a/themes/synthwave.yaml
+++ b/themes/synthwave.yaml
@@ -65,6 +65,8 @@ synthwave:
   switch-checked-color: 'var(--dark-primary-color)' # Background On
   paper-toggle-button-unchecked-button-color: 'var(--primary-text-color)' # Knob Off
   paper-toggle-button-unchecked-bar-color: 'var(--disabled-text-color)' # Background Off
+  ha-switch-thumb-background-color: 'var(--disabled-color)'
+  ha-switch-thumb-border-color: 'var(--disabled-color)'
 
   # Sliders
   slider-color: 'var(--primary-color)'

--- a/themes/synthwave.yaml
+++ b/themes/synthwave.yaml
@@ -8,6 +8,10 @@ synthwave:
   secondary-text-color: '#ffffffca'
   text-primary-color: '#f4eee4'
   disabled-text-color: '#bdbdbd'
+  disabled-color: '#848bbd'
+  rgb-disabled-color: '132, 139, 189'
+  mush-rgb-disabled: '132, 139, 189'
+  grey-color: '#848bbd'
   text-light-primary-color: '#fff'
 
   # main interface colors
@@ -24,32 +28,32 @@ synthwave:
   # iron-icon-fill-color: '#fff'
   yellow: '#ffcc00'
   green: '#72f1b8cc'
-  
+
   ###
-  
+
   # background and sidebar
   card-background-color: '#34294f'
   app-header-background-color: 'var(--primary-background-color)'
   paper-card-background-color: 'var(--card-background-color)'
   secondary-background-color: 'var(--light-primary-color)' # behind the cards on state
   ha-card-border-radius: '8px'
-  
+
   # sidebar menu
   sidebar-text-color: 'var(--secondary-text-color)'
   # sidebar-background-color: 'var(--paper-listbox-background-color)' # backward compatible with existing themes
   sidebar-icon-color: 'var(--secondary-text-color)'
   sidebar-selected-text-color: 'var(--primary-text-color)'
   sidebar-selected-icon-color: 'var(--primary-text-color)'
-  
+
   # mwc - for some reason it's buttons
   mdc-theme-primary: 'var(--dark-primary-color)'
   mdc-theme-secondary: 'var(--dark-primary-color)'
-  
+
   # shadows
   ha-card-box-shadow: '0'
 
   # icons
-  paper-item-icon-color: 'var(--secondary-text-color)'  # Off
+  paper-item-icon-color: 'var(--secondary-text-color)' # Off
   paper-item-icon-active-color: 'var(--yellow)' # On
 
   # switches
@@ -81,6 +85,9 @@ synthwave:
 
   # other
   state-icon-color: 'var(--green)'
+  state-inactive-color: '#848bbd'
+  rgb-state-inactive-color: '132, 139, 189'
+  state-climate-off-color: 'var(--state-inactive-color)'
   table-row-background-color: 'var(--divider-color)'
   table-row-alternative-background-color: 'var(--light-primary-color)'
   
@@ -106,7 +113,7 @@ synthwave:
   mdc-text-field-disabled-fill-color: 'var(--primary-background-color)'
   mdc-text-field-disabled-ink-color: 'var(--disabled-text-color)'
   mdc-text-field-disabled-dropdown-icon-color: 'var(--disabled-text-color)'
-  
+
   # Template Editor
   codemirror-keyword: '#36f9f6'
   codemirror-operator: '#36f9f6'
@@ -177,10 +184,10 @@ synthwave:
   ha-color-neutral-90: '#e4e3e7'
   ha-color-neutral-95: '#f1f1f3'
 
-  # override default values to make form fields readable
-  ha-color-form-background: 'var(--ha-color-primary-20)'
-  ha-color-form-background-disabled: 'var(--ha-color-primary-80)'
-  ha-color-form-background-hover: 'var(--ha-color-primary-50)'
+  # form fields / picker search
+  ha-color-form-background: '#3b3058'
+  ha-color-form-background-disabled: '#302742'
+  ha-color-form-background-hover: '#443668'
 
   # semantic color tokens from the default dark theme (Home Assistant 2026.1)
   ha-color-text-primary: var(--white-color)
@@ -208,13 +215,14 @@ synthwave:
   ha-color-fill-primary-normal-active: var(--ha-color-primary-10)
 
   ha-color-fill-neutral-quiet-resting: var(--ha-color-neutral-05)
-  ha-color-fill-neutral-quiet-f-fill-neutral-quiet-active: var(--ha-color-neutral-00)
+  ha-color-fill-neutral-quiet-active: var(--ha-color-neutral-05)
 
   ha-color-fill-neutral-normal-resting: var(--ha-color-neutral-10)
   ha-color-fill-neutral-normal-hover: var(--ha-color-neutral-20)
   ha-color-fill-neutral-normal-active: var(--ha-color-neutral-10)
 
   ha-color-fill-disabled-quiet-resting: var(--ha-color-neutral-10)
+  ha-color-fill-disabled-quiet-active: var(--ha-color-neutral-10)
 
   ha-color-fill-disabled-normal-resting: var(--ha-color-neutral-20)
 

--- a/themes/synthwave.yaml
+++ b/themes/synthwave.yaml
@@ -220,6 +220,7 @@ synthwave:
   ha-color-fill-neutral-normal-resting: var(--ha-color-neutral-10)
   ha-color-fill-neutral-normal-hover: var(--ha-color-neutral-20)
   ha-color-fill-neutral-normal-active: var(--ha-color-neutral-10)
+  wa-color-neutral-fill-normal: var(--ha-color-form-background-hover)
 
   ha-color-fill-disabled-quiet-resting: var(--ha-color-neutral-10)
   ha-color-fill-disabled-quiet-active: var(--ha-color-neutral-10)

--- a/themes/synthwave.yaml
+++ b/themes/synthwave.yaml
@@ -1,4 +1,8 @@
 synthwave:
+  modes:
+    dark:
+      primary-background-color: '#2a2139'
+
   # text
   primary-text-color: '#fff'
   secondary-text-color: '#ffffffca'

--- a/themes/synthwave.yaml
+++ b/themes/synthwave.yaml
@@ -34,6 +34,7 @@ synthwave:
   # background and sidebar
   card-background-color: '#34294f'
   app-header-background-color: 'var(--primary-background-color)'
+  app-header-edit-background-color: 'var(--app-header-background-color)'
   paper-card-background-color: 'var(--card-background-color)'
   secondary-background-color: 'var(--light-primary-color)' # behind the cards on state
   ha-card-border-radius: '8px'

--- a/themes/synthwave.yaml
+++ b/themes/synthwave.yaml
@@ -216,10 +216,11 @@ synthwave:
   ha-color-fill-primary-normal-active: var(--ha-color-primary-10)
 
   ha-color-fill-neutral-quiet-resting: var(--ha-color-neutral-05)
+  ha-color-fill-neutral-quiet-hover: var(--ha-color-form-background-hover)
   ha-color-fill-neutral-quiet-active: var(--ha-color-neutral-05)
 
-  ha-color-fill-neutral-normal-resting: var(--ha-color-neutral-10)
-  ha-color-fill-neutral-normal-hover: var(--ha-color-neutral-20)
+  ha-color-fill-neutral-normal-resting: var(--ha-color-form-background)
+  ha-color-fill-neutral-normal-hover: var(--ha-color-form-background-hover)
   ha-color-fill-neutral-normal-active: var(--ha-color-form-background-hover)
   wa-color-neutral-fill-normal: var(--ha-color-form-background-hover)
 
@@ -270,7 +271,7 @@ synthwave:
   ha-color-on-primary-normal: var(--ha-color-primary-60)
 
   ha-color-on-neutral-quiet: var(--ha-color-neutral-70)
-  ha-color-on-neutral-normal: var(--ha-color-neutral-60)
+  ha-color-on-neutral-normal: var(--primary-text-color)
   ha-color-on-neutral-loud: var(--white-color)
 
   ha-color-on-disabled-quiet: var(--ha-color-neutral-40)
@@ -289,5 +290,6 @@ synthwave:
   ha-color-on-success-normal: var(--ha-color-green-60)
   ha-color-on-success-loud: var(--white-color)
 
+  ha-color-surface-low: var(--ha-color-form-background)
   ha-color-surface-default: var(--ha-color-neutral-10)
   ha-color-on-surface-default: var(--ha-color-neutral-95)


### PR DESCRIPTION
hii
i found a hack to set the dark theme as the base, and i also improved lots of colors

| Before | After |
|--------|--------|
| <img width="850" height="735" alt="image" src="https://github.com/user-attachments/assets/41c5b666-6178-4003-968c-8113fca0ba03" /> | <img width="831" height="717" alt="image" src="https://github.com/user-attachments/assets/b7f23d77-1abd-4728-bd19-a54dbc6d5640" /> |

| Before | After |
|--------|--------|
| <img width="1552" height="231" alt="image" src="https://github.com/user-attachments/assets/69755e7e-125b-4910-b49d-b6b705070f59" /> | <img width="847" height="248" alt="image" src="https://github.com/user-attachments/assets/25227710-c952-4c3d-b5e3-43c602954368" /> |

| Before | After |
|--------|--------|
| <img width="1535" height="776" alt="image" src="https://github.com/user-attachments/assets/b8cad64f-cc21-4ee2-98f5-434ac1f14d08" /> | <img width="1543" height="774" alt="image" src="https://github.com/user-attachments/assets/947b3203-3428-4f53-8176-d53c317d2eaa" /> | 